### PR TITLE
Fix error caused by site layout change

### DIFF
--- a/Lifter.py
+++ b/Lifter.py
@@ -106,7 +106,7 @@ class Lifter(object):
         page = self.request_c(url)
         soup = BeautifulSoup(page.text, 'html.parser')
 
-        iframe_encoded = repr(soup.find("meta", {"itemprop": "embedURL"}).next_element.next_element)
+        iframe_encoded = repr(soup.find("meta", {"itemprop": "embedURL"}).previous_element)
         tag = re.search("^<([a-zA-Z]*)", iframe_encoded).group(1)
         if tag == 'script':
             iframe_decoded = self._decode_iframe(iframe_encoded)


### PR DESCRIPTION
wcostream has changed the order of a couple of the elements on their site, causing an error when attempting to download. This PR should fix this.

Prior to PR:
```
(venv) C:\Users\amvpj\Downloads\wco-dl>py __main__.py -i "https://www.wcostream.org/anime/bob-s-burgers" -se 1
Settings Loaded.
Downloads Loaded.

Newer version available, on https://github.com/EpicUnknown/wco-dl

Downloading show
Traceback (most recent call last):
  File "C:\Users\amvpj\Downloads\wco-dl\__main__.py", line 13, in <module>
    class Main:
  File "C:\Users\amvpj\Downloads\wco-dl\__main__.py", line 119, in Main
    Lifter(url=args.input[0].replace('https://wcostream.org', 'https://www.wcostream.org'), resolution=args.highdef, logger=logger, season=args.season,
  File "C:\Users\amvpj\Downloads\wco-dl\Lifter.py", line 62, in __init__
    self.download_show(url)
  File "C:\Users\amvpj\Downloads\wco-dl\Lifter.py", line 264, in download_show
    source_url, backup_url = self.find_download_link(item)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\amvpj\Downloads\wco-dl\Lifter.py", line 103, in find_download_link
    return self.get_download_url(self.find_hidden_url(url))
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\amvpj\Downloads\wco-dl\Lifter.py", line 116, in find_hidden_url
    raise Exception(f"Found unexpected element when searching for the iframe with tag='{tag}'")
Exception: Found unexpected element when searching for the iframe with tag='br'
```
After PR: Program functions as normal.

Figured I'd PR my fix back to this repository as this seems to be the most up-to-date fork. Hope this helps!